### PR TITLE
fix: clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,14 +112,14 @@ impl<'a> Cli {
     fn set_password_to_env_keys(
         &self,
         collection: &Collection<'a>,
-        namespace: &String,
-        env_keys: &Vec<String>,
+        namespace: &str,
+        env_keys: &[String],
     ) -> Result<(), Box<dyn Error>> {
         env_keys.iter().for_each(|env_key| {
             if let Ok(password) = prompt_password(format!("{}: ", env_key)) {
                 let properties = HashMap::from([
                     ("key", env_key.as_str()),
-                    ("name", namespace.as_str()),
+                    ("name", namespace),
                     ("xdg:schema", "envchain.EnvironmentVariable"),
                 ]);
                 let _ = collection.create_item(
@@ -139,8 +139,8 @@ impl<'a> Cli {
     fn run_command(
         &self,
         collection: &Collection<'a>,
-        namespace: &String,
-        command: &Vec<String>,
+        namespace: &str,
+        command: &[String],
     ) -> Result<(), Box<dyn Error>> {
         let envs = self.build_envs(collection, namespace);
         let (exe, args) = command.split_at(1);
@@ -226,7 +226,7 @@ impl<'a> Cli {
     fn import_secrets(
         &self,
         collection: &Collection<'a>,
-        input: &String,
+        input: &str,
     ) -> Result<(), Box<dyn Error>> {
         let mut io = File::open(input)?;
         let mut toml = String::new();


### PR DESCRIPTION
```
❯ cargo clippy
    Checking envchain-rs v0.1.5 (/home/kenji/wc/src/github.com/okkez/envchain-rs)
warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> src/main.rs:116:19
    |
116 |         env_keys: &Vec<String>,
    |                   ^^^^^^^^^^^^ help: change this to: `&[String]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
    = note: `#[warn(clippy::ptr_arg)]` on by default

warning: writing `&String` instead of `&str` involves a new object where a slice will do
   --> src/main.rs:142:20
    |
142 |         namespace: &String,
    |                    ^^^^^^^ help: change this to: `&str`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> src/main.rs:143:18
    |
143 |         command: &Vec<String>,
    |                  ^^^^^^^^^^^^ help: change this to: `&[String]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: `envchain-rs` (bin "envchain") generated 3 warnings
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance and memory usage by optimizing internal string and vector handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->